### PR TITLE
replacing "include" in sequelize object to get information for cases api

### DIFF
--- a/routes/api/case.js
+++ b/routes/api/case.js
@@ -23,6 +23,7 @@ router.get("/api/cases/:id", (req, res) => {
     where: {
       id,
     },
+    include: [db.Type, db.Division, "Attorneyp", "Attorneyd", "plaint", "def"],
   }).then((oneCase) => {
     res.json(oneCase);
   });


### PR DESCRIPTION
updating routes/api/cases.js with the include to bring in pivont tables, division, and type